### PR TITLE
Document APIs behind feature flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Create doc
-        run: cargo doc
+        run: cargo doc --all-features
+        env:
+          RUSTDOCFLAGS: --cfg docsrs # mimic docs.rs build
 
   Tests:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,5 @@ categories = ["embedded", "no-std"]
 allocator-api = []
 max-usage = []
 
+[package.metadata.docs.rs]
+all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![no_std]
 #![deny(missing_docs)]
 #![cfg_attr(feature = "allocator-api", feature(allocator_api))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use core::alloc::{GlobalAlloc, Layout};
 use core::sync::atomic::{AtomicUsize, Ordering};


### PR DESCRIPTION
Build the documentation with all features enabled. This improves the discoverability. For APIs behind feature flags, use [`doc_auto_cfg`](https://github.com/rust-lang/rust/issues/43781) to add a note about the required features:

![image](https://github.com/user-attachments/assets/e2d96937-b73f-4522-bdca-3014b0b34c41)

The docs build CI job mimics a [docs.rs build](https://docs.rs/about/builds) by setting the `docsrs` configuration flag.